### PR TITLE
Added Headers to Minerpage

### DIFF
--- a/libs/website.js
+++ b/libs/website.js
@@ -228,6 +228,7 @@ module.exports = function(logger){
 			address = address.split(".")[0];
             portalStats.getBalanceByAddress(address, function(){
                 processTemplates();
+		res.header('Content-Type', 'text/html');
                 res.end(indexesProcessed['miner_stats']);
             });
         }


### PR DESCRIPTION
Chrome was wrapping the minerpage function output in a <pre> element and not rendering the worker stat page properly. I added `res.header('Content-Type', 'text/html');` to the function and now it renders perfectly.